### PR TITLE
fix tensorflow.so for latest master

### DIFF
--- a/Formula/tensorflow_c.rb
+++ b/Formula/tensorflow_c.rb
@@ -1,4 +1,4 @@
-class TensorflowC < Formula
+class Tensorflow < Formula
   desc "C interface for Google's OS library for Machine Intelligence"
   homepage "https://www.tensorflow.org/"
   url "https://github.com/tensorflow/tensorflow", :using => :git,
@@ -9,19 +9,19 @@ class TensorflowC < Formula
 
   def install
     system 'echo "\n\n\n\n\n\n\n\n\n" | ./configure'
-    system "bazel", "build", "--compilation_mode=opt", "--copt=-march=native", "tensorflow:libtensorflow_c.so"
-    lib.install "bazel-bin/tensorflow/libtensorflow_c.so"
-    cp "tensorflow/c/c_api.h", "tensorflow_c_api.h"
-    include.install "tensorflow_c_api.h"
+    system "bazel", "build", "--compilation_mode=opt", "--copt=-march=native", "tensorflow:libtensorflow.so"
+    lib.install "bazel-bin/tensorflow/libtensorflow.so"
+    cp "tensorflow/c/c_api.h", "tensorflow_api.h"
+    include.install "tensorflow_api.h"
     pc = <<-EOF.gsub(/^\s+/, "")
-      Name: tensorflow_c
+      Name: tensorflow
       Description: Tensorflow c lib
       Version: #{version}
-      Libs: -L#{lib} -ltensorflow_c
+      Libs: -L#{lib} -ltensorflow
       Cflags: -I#{include}
     EOF
     mkdir_p(lib/"pkgconfig")
-    File.open(lib/"pkgconfig/tensorflow_c.pc", "w") { |f| f.write(pc) }
+    File.open(lib/"pkgconfig/tensorflow.pc", "w") { |f| f.write(pc) }
   end
 
   test do
@@ -29,13 +29,13 @@ class TensorflowC < Formula
     File.open("test.c", "w") do |f|
       f.write(<<-EOF.gsub(/^\s+/, ""))
       #include <stdio.h>
-      #include <tensorflow_c_api.h>
+      #include <tensorflow_api.h>
       int main() {
         printf("%s\\n", TF_Version());
       }
       EOF
     end
-    system "sh", "-c", "gcc `pkg-config --libs --cflags tensorflow_c` -o test_tf test.c"
+    system "sh", "-c", "gcc `pkg-config --libs --cflags tensorflow` -o test_tf test.c"
     found_version = `./test_tf`.strip
     assert found_version == version
   end


### PR DESCRIPTION
Hi,

we fixed tensorflow_c to tensorflow in the upstream crate, so this change makes it still possible to work with the upcoming release. Or if you want `tensorflow = { git = "https://github.com/tensorflow/rust" }`